### PR TITLE
NER bug fix

### DIFF
--- a/klue_baseline/metrics/functional.py
+++ b/klue_baseline/metrics/functional.py
@@ -57,7 +57,7 @@ def klue_ner_entity_macro_f1(preds: np.ndarray, labels: np.ndarray, label_list: 
 
 def klue_ner_char_macro_f1(preds: np.ndarray, labels: np.ndarray, label_list: List[str]) -> Any:
     """KLUE-NER character level macro f1 (except O tag)"""
-    label_indices = list(range(len(label_list)))
+    label_indices = list(range(len(label_list) - 1))
     preds = np.array(preds).flatten().tolist()
     trues = np.array(labels).flatten().tolist()
     return sklearn.metrics.f1_score(trues, preds, labels=label_indices, average="macro", zero_division=True) * 100.0


### PR DESCRIPTION
Original code includes 'O' class when calculating f1 score, which should have been excluded based on what KLUE paper says. This commit fixes the issue.
기존 코드는 NER F1 score 계산 시 'O' class를 포함하고 있습니다. KLUE 논문에 따르면 'O' class는 계산 시 제외되어야 합니다. 이 PR은 해당 문제를 fix 합니다.